### PR TITLE
fix(ui): 図書関連のURL周りを修正

### DIFF
--- a/app/src/main/java/com/tokudai0000/tokumemo/common/AppConstants.kt
+++ b/app/src/main/java/com/tokudai0000/tokumemo/common/AppConstants.kt
@@ -37,7 +37,7 @@ object AppConstants {
             MenuDetailItem(title="蔵本図書館 カレンダー", id= MenuDetailItem.Type.LibraryCalendarKura, targetUrl=Url.LibraryHomePageKuraPC.urlString),
             MenuDetailItem(title="貸出図書の期間延長", id= MenuDetailItem.Type.LibraryBookLendingExtension, targetUrl= Url.LibraryBookLendingExtension.urlString),
             MenuDetailItem(title="本の購入リクエスト", id= MenuDetailItem.Type.LibraryBookPurchaseRequest, targetUrl= Url.LibraryBookPurchaseRequest.urlString),
-            MenuDetailItem(title="マイページ", id= MenuDetailItem.Type.LibraryMyPage, targetUrl= Url.LibraryMyPage.toString()),
+            MenuDetailItem(title="マイページ", id= MenuDetailItem.Type.LibraryMyPage, targetUrl= Url.LibraryMyPage.urlString),
         )
 
         etcItems = listOf(

--- a/app/src/main/java/com/tokudai0000/tokumemo/ui/main/fragment/home/HomeFragment.kt
+++ b/app/src/main/java/com/tokudai0000/tokumemo/ui/main/fragment/home/HomeFragment.kt
@@ -177,24 +177,9 @@ class HomeFragment : Fragment() {
         val itemNames = items.map { it.title }.toTypedArray()
 
         builder.setItems(itemNames) { dialog, which ->
-            // 図書館カレンダー.pdfのURLをWebスクレイピングしてくる
-            if (items[which].id == MenuDetailItem.Type.LibraryCalendarMain ||
-                items[which].id == MenuDetailItem.Type.LibraryCalendarKura ) {
-                items[which].targetUrl?.let {
-                    viewModel.getLibraryCalendarURL(it)
-                    viewModel.libraryCalendarURL.observe(viewLifecycleOwner) { urlStr ->
-                        val intent = Intent(requireContext(), WebActivity::class.java)
-                        val url = UrlCheckers.convertToGoogleDocsViewerUrlIfNeeded(urlStr)
-                        intent.putExtra(WebActivity.KEY_URL, url)
-                        startActivity(intent)
-                        AKLog(AKLogLevel.DEBUG, "URL - $url")
-                    }
-                }
-            }else{
                 val intent = Intent(requireContext(), WebActivity::class.java)
                 intent.putExtra(WebActivity.KEY_URL, items[which].targetUrl)
                 startActivity(intent)
-            }
         }
 
         val dialog = builder.create()


### PR DESCRIPTION
## 概要
図書関連にあった不具合を修正。

## 説明
- 常三島/蔵本カレンダーにアクセスしようとした際にpdfへ変換をしていたが、現在はそもそもこのURLは使われていないので変換ができず、`http://null/`へアクセスしていた問題を修正。
- マイページにアクセスした際に、urlStringではなく、toString()を呼び出して、`http://librarymypage/`へアクセスしていた問題を修正

## その他（懸念点や注意点）
アカウントを維持するための更新です。